### PR TITLE
fix: get sha using gh cli and add pull request

### DIFF
--- a/updatecli/policies/apm/ecs-logging-specs/CHANGELOG.md
+++ b/updatecli/policies/apm/ecs-logging-specs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Fix PR description
+
 ## 0.1.0
 
 * Init policy

--- a/updatecli/policies/apm/ecs-logging-specs/Policy.yaml
+++ b/updatecli/policies/apm/ecs-logging-specs/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/elastic/oblt-updatecli-policies/"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/ecs-logging-specs/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/ecs-logging-specs/"
-version: 0.1.0
+version: 0.2.0
 vendor: Elastic Project
 
 licenses:


### PR DESCRIPTION
This will avoid a wrong description https://github.com/elastic/oblt-updatecli-policies/pull/15

Use GH_TOKEN in conjunction with the `gh cli` command, this will avoid API quota issues