### PR TITLE
fix: commits API is not returning a valid sha commit

### DIFF
--- a/updatecli/policies/apm/ecs-logging-specs/CHANGELOG.md
+++ b/updatecli/policies/apm/ecs-logging-specs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* Fix API call to gather the sha commit
+
 ## 0.2.0
 
 * Fix PR description

--- a/updatecli/policies/apm/ecs-logging-specs/Policy.yaml
+++ b/updatecli/policies/apm/ecs-logging-specs/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/elastic/oblt-updatecli-policies/"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/ecs-logging-specs/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/ecs-logging-specs/"
-version: 0.2.0
+version: 0.3.0
 vendor: Elastic Project
 
 licenses:

--- a/updatecli/policies/apm/ecs-logging-specs/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/ecs-logging-specs/updatecli.d/default.tpl
@@ -11,7 +11,7 @@ sources:
   sha:
     kind: shell
     spec:
-      command: gh api /repos/{{ default $GitHubRepositoryList._0 .scm.owner }}/ecs-logging/contents/spec/spec.json --jq .sha
+      command: gh api "/repos/{{ default $GitHubRepositoryList._0 .scm.owner }}/ecs-logging/commits?path=spec/spec.json" --jq '.[0].sha'
       environments:
         - name: GITHUB_TOKEN
         - name: PATH


### PR DESCRIPTION
```bash
$ sha=$(gh api /repos/elastic/ecs-logging/contents/spec/spec.json --jq .sha)
$ gh api /repos/elastic/ecs-logging/commits/$sha/pulls
{
gh: No commit found for SHA: 68f32d704f78e90a58b0ca7c501769234b731e39 (HTTP 422)
  "message": "No commit found for SHA: 68f32d704f78e90a58b0ca7c501769234b731e39",
  "documentation_url": "https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit",
  "status": "422"
}

```