### PR TITLE
feat: use scm.commitusingapi

### DIFF
--- a/updatecli/policies/apm/apm-data-spec/CHANGELOG.md
+++ b/updatecli/policies/apm/apm-data-spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+
 ## 0.3.0
 
 * No changes

--- a/updatecli/policies/apm/apm-data-spec/testdata/values.yaml
+++ b/updatecli/policies/apm/apm-data-spec/testdata/values.yaml
@@ -4,5 +4,6 @@ scm:
   repository: oblt-updatecli-policies
   username: obltmachine
   branch: main
+  commitusingapi: true
 
 apm_schema_specs_path: tests/apm/apm-data-spec/specs

--- a/updatecli/policies/apm/apm-data-spec/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/apm-data-spec/updatecli.d/default.tpl
@@ -62,8 +62,8 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-#{{ if .signedcommit }}
-      commitusingapi: {{ .signedcommit }}
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
 # {{ end }}
 
   apm-data:

--- a/updatecli/policies/apm/apm-data-spec/values.yaml
+++ b/updatecli/policies/apm/apm-data-spec/values.yaml
@@ -4,8 +4,6 @@ automerge: false
 
 # apm_schema_specs_path: 
 
-signedcommit: false
-
 scm:
   enabled: false
   # owner: v1v
@@ -13,3 +11,4 @@ scm:
   # token: "xxx"
   # username: "v1v-bot"
   # branch: main
+  # commitusingapi: false

--- a/updatecli/policies/apm/apm-gherkin/CHANGELOG.md
+++ b/updatecli/policies/apm/apm-gherkin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+
 ## 0.3.0
 
 * No changes

--- a/updatecli/policies/apm/apm-gherkin/testdata/values.yaml
+++ b/updatecli/policies/apm/apm-gherkin/testdata/values.yaml
@@ -4,5 +4,6 @@ scm:
   repository: oblt-updatecli-policies
   username: obltmachine
   branch: main
+  commitusingapi: true
 
 apm_gherkin_specs_path: tests/apm/apm-gherkin/specs

--- a/updatecli/policies/apm/apm-gherkin/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/apm-gherkin/updatecli.d/default.tpl
@@ -62,8 +62,8 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-#{{ if .signedcommit }}
-      commitusingapi: {{ .signedcommit }}
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
 # {{ end }}
 
   apm:

--- a/updatecli/policies/apm/apm-gherkin/values.yaml
+++ b/updatecli/policies/apm/apm-gherkin/values.yaml
@@ -4,8 +4,6 @@ automerge: false
 
 # apm_gherkin_specs_path: 
 
-signedcommit: false
-
 scm:
   enabled: false
   # owner: v1v
@@ -13,3 +11,4 @@ scm:
   # token: "xxx"
   # username: "v1v-bot"
   # branch: main
+  # commitusingapi: false

--- a/updatecli/policies/apm/apm-json-specs/CHANGELOG.md
+++ b/updatecli/policies/apm/apm-json-specs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+
 ## 0.3.0
 
 * No changes

--- a/updatecli/policies/apm/apm-json-specs/testdata/values.yaml
+++ b/updatecli/policies/apm/apm-json-specs/testdata/values.yaml
@@ -4,5 +4,6 @@ scm:
   repository: oblt-updatecli-policies
   username: obltmachine
   branch: main
+  commitusingapi: true
 
 apm_json_specs_path: tests/apm/apm-json-specs/specs

--- a/updatecli/policies/apm/apm-json-specs/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/apm-json-specs/updatecli.d/default.tpl
@@ -62,8 +62,8 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-#{{ if .signedcommit }}
-      commitusingapi: {{ .signedcommit }}
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
 # {{ end }}
 
   apm:

--- a/updatecli/policies/apm/apm-json-specs/values.yaml
+++ b/updatecli/policies/apm/apm-json-specs/values.yaml
@@ -4,8 +4,6 @@ automerge: false
 
 # apm_json_specs_path: 
 
-signedcommit: false
-
 scm:
   enabled: false
   # owner: v1v
@@ -13,3 +11,4 @@ scm:
   # token: "xxx"
   # username: "v1v-bot"
   # branch: main
+  # commitusingapi: false

--- a/updatecli/policies/apm/ecs-logging-specs/CHANGELOG.md
+++ b/updatecli/policies/apm/ecs-logging-specs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+
 ## 0.3.0
 
 * Fix API call to gather the sha commit

--- a/updatecli/policies/apm/ecs-logging-specs/testdata/values.yaml
+++ b/updatecli/policies/apm/ecs-logging-specs/testdata/values.yaml
@@ -4,5 +4,6 @@ scm:
   repository: oblt-updatecli-policies
   username: obltmachine
   branch: main
+  commitusingapi: true
 
 spec_path: tests/apm/ecs-logging-specs/spec.json

--- a/updatecli/policies/apm/ecs-logging-specs/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/ecs-logging-specs/updatecli.d/default.tpl
@@ -53,8 +53,8 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-#{{ if .signedcommit }}
-      commitusingapi: {{ .signedcommit }}
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
 # {{ end }}
 
 actions:

--- a/updatecli/policies/apm/ecs-logging-specs/values.yaml
+++ b/updatecli/policies/apm/ecs-logging-specs/values.yaml
@@ -4,8 +4,6 @@ automerge: false
 
 # spec_path: 
 
-signedcommit: false
-
 scm:
   enabled: false
   # owner: v1v
@@ -13,3 +11,4 @@ scm:
   # token: "xxx"
   # username: "v1v-bot"
   # branch: main
+  # commitusingapi: false

--- a/updatecli/policies/golang/version/CHANGELOG.md
+++ b/updatecli/policies/golang/version/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+
 ## 0.1.5
 
 * `signedcommit` does not work if experimental is disabled.

--- a/updatecli/policies/golang/version/testdata/values.yaml
+++ b/updatecli/policies/golang/version/testdata/values.yaml
@@ -6,5 +6,6 @@ scm:
   repository: oblt-updatecli-policies
   username: obltmachine
   branch: main
+  commitusingapi: true
 
 path: tests/golang/version

--- a/updatecli/policies/golang/version/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/version/updatecli.d/default.tpl
@@ -46,8 +46,8 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-#{{ if .signedcommit }}
-      commitusingapi: {{ .signedcommit }}
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
 # {{ end }}
 
 actions:

--- a/updatecli/policies/golang/version/values.yaml
+++ b/updatecli/policies/golang/version/values.yaml
@@ -4,8 +4,6 @@ automerge: false
 
 path: .
 
-signedcommit: false
-
 scm:
   enabled: false
   # user: v1v-bot
@@ -15,4 +13,5 @@ scm:
   # token: "xxx"
   # username: "v1v-bot"
   # branch: main
+  # commitusingapi: false
 

--- a/updatecli/policies/ironbank/templates/CHANGELOG.md
+++ b/updatecli/policies/ironbank/templates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+
 ## 0.1.0
 
 - Packages are unrelated to the paths data structure, let's be explict it's about beats/elastic-agent

--- a/updatecli/policies/ironbank/templates/testdata/values.yaml
+++ b/updatecli/policies/ironbank/templates/testdata/values.yaml
@@ -5,6 +5,7 @@ scm:
   repository: oblt-updatecli-policies
   username: obltmachine
   branch: main
+  commitusingapi: true
 
 config:
   - path: tests/ironbank/templates/apm-server

--- a/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
+++ b/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
@@ -79,8 +79,8 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-# {{ if .signedcommit }}
-      commitusingapi: {{ .signedcommit }}
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
 # {{ end }}
 
 actions:

--- a/updatecli/policies/ironbank/templates/values.yaml
+++ b/updatecli/policies/ironbank/templates/values.yaml
@@ -11,9 +11,6 @@ config:
 ubi_version_path: https://repo1.dso.mil/dsop/redhat/ubi/9.x/ubi9
 ubi_version_branch: master
 
-# TODO: maybe to be moved to the scm section? If so, let's plan this breanking change.
-signedcommit: false
-
 scm:
   enabled: false
   # user: v1v-bot
@@ -22,6 +19,7 @@ scm:
   # token: "xxx"
   # username: "v1v-bot"
   # branch: main
+  # commitusingapi: false
 
 pull_request:
   labels:

--- a/updatecli/policies/oblt-cli/version/CHANGELOG.md
+++ b/updatecli/policies/oblt-cli/version/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+
 ## 0.1.0
 
 - Initial release

--- a/updatecli/policies/oblt-cli/version/testdata/values.yaml
+++ b/updatecli/policies/oblt-cli/version/testdata/values.yaml
@@ -5,6 +5,7 @@ scm:
   repository: oblt-updatecli-policies
   username: obltmachine
   branch: main
+  commitusingapi: true
 
 path: tests/oblt-cli/version/.tool-versions
 

--- a/updatecli/policies/oblt-cli/version/updatecli.d/default.tpl
+++ b/updatecli/policies/oblt-cli/version/updatecli.d/default.tpl
@@ -51,8 +51,8 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-# {{ if .signedcommit }}
-      commitusingapi: {{ .signedcommit }}
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
 # {{ end }}
 
 actions:

--- a/updatecli/policies/oblt-cli/version/values.yaml
+++ b/updatecli/policies/oblt-cli/version/values.yaml
@@ -4,8 +4,6 @@ automerge: false
 
 path: .tool-versions
 
-signedcommit: false
-
 scm:
   enabled: false
   # user: v1v-bot
@@ -14,6 +12,7 @@ scm:
   # token: "xxx"
   # username: "v1v-bot"
   # branch: main
+  # commitusingapi: false
 
 pull_request:
   labels:


### PR DESCRIPTION
Then I plan to follow-up with the publishing  in a different PR.


by normalising the commit signing we can benefit from reusing what i did in https://github.com/updatecli/policies/pull/28

Side effect: when the bump happens, we need to update the config files too.

