### PR TITLE
feat: skip udpating dockerfile or manifest if set explicitly

### DIFF
--- a/tests/ironbank/templates/only-dockerfile/Dockerfile
+++ b/tests/ironbank/templates/only-dockerfile/Dockerfile
@@ -1,0 +1,3 @@
+ARG BASE_REGISTRY=registry1.dsop.io
+ARG BASE_IMAGE=redhat/ubi/ubi9
+ARG BASE_TAG=9.3

--- a/tests/ironbank/templates/only-manifest/hardening_manifest.yaml
+++ b/tests/ironbank/templates/only-manifest/hardening_manifest.yaml
@@ -1,0 +1,4 @@
+---
+args:
+  BASE_IMAGE: "redhat/ubi/ubi9"
+  BASE_TAG: "9.3"

--- a/updatecli/policies/ironbank/templates/CHANGELOG.md
+++ b/updatecli/policies/ironbank/templates/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Support manifest entries that cannot be parsed with the yaml kind
 - Breaking change: `scm.commitusingapi` is the way to sign commits automatically. Replace `signedcommit`.
+- Skip updating Dockerimage if `skip_dockerfile: true`. Default 'skip_dockerfile: false'.
+- Skip updating Manifest if `skip_manifest: true`. Default 'skip_manifest: false'.
 
 ## 0.1.0
 

--- a/updatecli/policies/ironbank/templates/testdata/values.yaml
+++ b/updatecli/policies/ironbank/templates/testdata/values.yaml
@@ -18,6 +18,10 @@ config:
   - path: tests/ironbank/templates/ent-search
     dockerfile: Dockerfile.erb
     manifest: hardening_manifest.yaml.erb
+  - path: tests/ironbank/templates/only-dockerfile
+    skip_manifest: true
+  - path: tests/ironbank/templates/only-manifest
+    skip_dockerfile: true
 
 pull_request:
   labels:

--- a/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
+++ b/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
@@ -24,6 +24,8 @@ targets:
 # {{ range .config }}
 
 # {{ if .path }}
+
+# {{ if not .skip_manifest }}
   hardening_manifest_{{ .path | base }}.yaml:
 # {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
     scmid: default
@@ -44,7 +46,9 @@ targets:
       matchpattern: 'BASE_TAG: ".*"'
       replacepattern: 'BASE_TAG: "{{ source "ubi_version" }}"'
 # {{ end }}
+# {{ end }} # end if not .skip_manifest
 
+# {{ if not .skip_dockerfile }}
   dockerfile_{{ .path | base }}:
 # {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
     scmid: default
@@ -57,7 +61,9 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "BASE_TAG"
-# {{ end }}
+# {{ end }} # end if not .skip_dockerfile
+
+# {{ end }} # end if .path
 
 # Elastic Agent and Beats use a packaging yaml definition
 # {{ if .beats_packages }}
@@ -74,7 +80,7 @@ targets:
       replacepattern: 'from: $1:{{ source "ubi_version" }}'
 # {{ end }}
 
-# {{ end }}
+# {{ end }} # end range .config
 
 # {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
 scms:

--- a/updatecli/policies/ironbank/templates/values.yaml
+++ b/updatecli/policies/ironbank/templates/values.yaml
@@ -6,6 +6,11 @@ config:
   - path: .
     dockerfile: Dockerfile
     manifest: hardening_manifest.yaml
+    # docs: if the dockerfile does not need to be updated, set this to true
+    skip_dockerfile: false
+    # docs: if the manifest does not need to be updated, set this to true
+    skip_manifest: false
+  # docs: beats and elastic agent use a specific file to define the different packages they release.
 # - beats_packages: my-relative-path/packages.yml
 
 ubi_version_path: https://repo1.dso.mil/dsop/redhat/ubi/9.x/ubi9


### PR DESCRIPTION
See https://github.com/elastic/ent-search/pull/8086/files#diff-96892c1c22309fa1b67a9cf0acf05b8354ca7d5128815ab5b336d709723750a1R4

In a nutshell, some implementations use different locations for storing the Dockefile and Hardening Manifest. 

Current opinionated approach uses the path where those files are stored... rather than using relative paths. For such, we cannot use the current implementation unless we enable the opt-out features for updating dockerfile or manifest.