### PR TITLE
fix: match for ent_search_ruby

### DIFF
--- a/updatecli/policies/ironbank/templates/CHANGELOG.md
+++ b/updatecli/policies/ironbank/templates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+* Fix match `@base_tag =: ` for `@base_tag = ` instead
+
 ## 0.5.0
 
 * Add support for `ent-search` ruby changes, `.ent_search_ruby` should point to dod.rb.

--- a/updatecli/policies/ironbank/templates/Policy.yaml
+++ b/updatecli/policies/ironbank/templates/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/elastic/oblt-updatecli-policies/"
 changelog: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/ironbank/templates/CHANGELOG.md"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/ironbank/templates/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/ironbank/templates/"
-version: 0.5.0
+version: 0.5.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
+++ b/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
@@ -75,8 +75,8 @@ targets:
     kind: file
     spec:
       file: {{ .ent_search_ruby }}
-      matchpattern: "@base_tag =: (')(.+)(')"
-      replacepattern: '@base_tag =: $1{{ source "ubi_version" }}$3'
+      matchpattern: "@base_tag = (')(.+)(')"
+      replacepattern: '@base_tag = $1{{ source "ubi_version" }}$3'
 # {{ end }} # end if .ent_search_ruby
 
 # Elastic Agent and Beats use a packaging yaml definition


### PR DESCRIPTION


fix the wrong match :/

```rb
      case build_environment
      when :ubi9
        @base_image = 'ubi9/ubi'
        @base_tag = '9.4'
      end
```