### PR TITLE
use dependson required when using >= v0.86.0

### DIFF
--- a/updatecli/policies/apm/apm-data-spec/CHANGELOG.md
+++ b/updatecli/policies/apm/apm-data-spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Use `dependson` to create dependency with Sources and Target. See https://github.com/updatecli/updatecli/releases/tag/v0.86.0
+
 ## 0.5.0
 
 * chore: add changelog URL in the policy

--- a/updatecli/policies/apm/apm-data-spec/Policy.yaml
+++ b/updatecli/policies/apm/apm-data-spec/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/elastic/oblt-updatecli-policies/"
 changelog: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-data-spec/CHANGELOG.md"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-data-spec/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-data-spec/"
-version: 0.5.0
+version: 0.6.0
 vendor: Elastic Project
 
 licenses:

--- a/updatecli/policies/apm/apm-data-spec/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/apm-data-spec/updatecli.d/default.tpl
@@ -41,6 +41,8 @@ targets:
     name: APM agent json server schema {{ source "sha" }}
     disablesourceinput: true
     kind: shell
+    dependson:
+      - source#agent-specs-tarball
     spec:
       # git diff helps to print what it changed, If it is empty, then updatecli report a success with no changes applied.
       # See https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target

--- a/updatecli/policies/apm/apm-gherkin/CHANGELOG.md
+++ b/updatecli/policies/apm/apm-gherkin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Use `dependson` to create dependency with Sources and Target. See https://github.com/updatecli/updatecli/releases/tag/v0.86.0
+
 ## 0.5.0
 
 * chore: add changelog URL in the policy

--- a/updatecli/policies/apm/apm-gherkin/Policy.yaml
+++ b/updatecli/policies/apm/apm-gherkin/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/elastic/oblt-updatecli-policies/"
 changelog: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-gherkin/CHANGELOG.md"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-gherkin/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-gherkin/"
-version: 0.5.0
+version: 0.6.0
 vendor: Elastic Project
 
 licenses:

--- a/updatecli/policies/apm/apm-gherkin/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/apm-gherkin/updatecli.d/default.tpl
@@ -41,6 +41,8 @@ targets:
     name: APM agent gherkin specs {{ source "sha" }}
     disablesourceinput: true
     kind: shell
+    dependson:
+      - source#agents-gherkin-specs-tarball
     spec:
       # git diff helps to print what it changed, If it is empty, then updatecli report a success with no changes applied.
       # See https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target

--- a/updatecli/policies/apm/apm-json-specs/CHANGELOG.md
+++ b/updatecli/policies/apm/apm-json-specs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Use `dependson` to create dependency with Sources and Target. See https://github.com/updatecli/updatecli/releases/tag/v0.86.0
+
 ## 0.5.0
 
 * chore: add changelog URL in the policy

--- a/updatecli/policies/apm/apm-json-specs/Policy.yaml
+++ b/updatecli/policies/apm/apm-json-specs/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/elastic/oblt-updatecli-policies/"
 changelog: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-json-specs/CHANGELOG.md"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-json-specs/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/apm/apm-json-specs/"
-version: 0.5.0
+version: 0.6.0
 vendor: Elastic Project
 
 licenses:

--- a/updatecli/policies/apm/apm-json-specs/updatecli.d/default.tpl
+++ b/updatecli/policies/apm/apm-json-specs/updatecli.d/default.tpl
@@ -41,6 +41,8 @@ targets:
     name: APM agent json specs {{ source "sha" }}
     disablesourceinput: true
     kind: shell
+    dependson:
+      - source#agents-json-specs-tarball
     spec:
       # git diff helps to print what it changed, If it is empty, then updatecli report a success with no changes applied.
       # See https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target


### PR DESCRIPTION
> Sources were always executed before conditions and then targets.

Breaking change in https://github.com/updatecli/updatecli/releases/tag/v0.86.0

Therefore, our updatecli pipelines are failing:
- https://github.com/elastic/apm-agent-go/actions/runs/11907199241/job/33185589539

```
target: target#agent-json-specs
-----------------------

**Dry Run enabled**

The shell 🐚 command "/bin/sh /tmp/updatecli/bin/68b2939c124c411192667268d8f6edefbaa79f085494796eb8122c21afdb37bf.sh" exited on error (exit code 2) with the following output:
----
----

command stderr output was:
----
tar (child): /home/runner/work/apm-agent-go/apm-agent-go/json-specs.tgz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
````