### PR TITLE
fix: use v prefix

### DIFF
--- a/updatecli/policies/updatecli/version/CHANGELOG.md
+++ b/updatecli/policies/updatecli/version/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Use release version with the v prefix
+
 ## 0.1.0
 
 - Initial release

--- a/updatecli/policies/updatecli/version/Policy.yaml
+++ b/updatecli/policies/updatecli/version/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/elastic/oblt-updatecli-policies/"
 changelog: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/updatecli/version/CHANGELOG.md"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/updatecli/version/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/updatecli/version/"
-version: 0.1.0
+version: 0.2.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/updatecli/version/updatecli.d/default.tpl
+++ b/updatecli/policies/updatecli/version/updatecli.d/default.tpl
@@ -31,7 +31,7 @@ targets:
     spec:
       file: '{{ .path }}'
 # {{ if hasSuffix ".tool-versions" .path }}
-      matchpattern: '^updatecli\s+\d+\.\d+\.\d+'
+      matchpattern: '^updatecli\s+v\d+\.\d+\.\d+'
       content: 'updatecli {{ source `version` }}'
 # {{ else }}
       # |+ adds newline to the end of the file


### PR DESCRIPTION
`v` prefix is needed