### PR TITLE
use pinned version for the updatecli and support auto-bump

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,11 +37,13 @@ jobs:
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose diff
+          version-file: .tool-versions
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose apply
+          version-file: .tool-versions
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup updatecli
-        uses: updatecli/updatecli-action@v2
+        uses: elastic/oblt-actions/updatecli/install@v1
+        with:
+          version-file: .tool-versions
 
       - name: Log in to the Container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Setup updatecli
-        uses: updatecli/updatecli-action@v2
+        uses: elastic/oblt-actions/updatecli/install@v1
+        with:
+          version-file: .tool-versions
 
       - name: Setup releasepost
         uses: updatecli/releasepost-action@108e7be5e43d1d1dc1177389a318d3630f6b01f1 # v0.4.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+updatecli v0.88.0

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -38,3 +38,8 @@ policies:
     policy: ghcr.io/elastic/oblt-updatecli-policies/updatecli/version:latest
     values:
       - updatecli/policies/updatecli/version/testdata/values.yaml
+
+  - name: Handle updatecli update
+    policy: ghcr.io/elastic/oblt-updatecli-policies/updatecli/version:latest
+    values:
+      - updatecli/values.d/scm.yaml

--- a/updatecli/values.d/scm.yaml
+++ b/updatecli/values.d/scm.yaml
@@ -1,0 +1,10 @@
+scm:
+  enabled: true
+  owner: elastic
+  repository: oblt-updatecli-policies
+  branch: main
+  commitusingapi: true
+  # begin update-compose policy values
+  user: obltmachine
+  email: obltmachine@users.noreply.github.com
+  # end update-compose policy values


### PR DESCRIPTION
We need to pin the version since 0.86.0 introduced a breaking change and the existing policies are now using that new feature. Therefore the e2e-tests are failing.

