### PR TITLE
chore: add some further docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ The version will be used as the "tag" for the policy such as `ghcr.io/updatecli/
 
 Any change to the policy code must be reflected by a new version. Policies are automatically published on `ghcr.io` if the version is updated.
 
-## How to test this locally
+## How to test this?
+
+### locally
 
 A specific policy under the `updatecli` folder:
 
@@ -54,3 +56,10 @@ RELEASEPOST_GITHUB_TOKEN=$(gh auth token) \
 GITHUB_WORKSPACE=$(pwd) \
 make e2e-test
 ```
+
+### CI
+
+You can run https://github.com/elastic/oblt-updatecli-policies/actions/workflows/e2e.yml through the
+UI.
+
+However, it's recommended to close all the open PRs related to the e2e that were already open.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains a list of common Updatecli published on `ghcr.io/elasti
 
 **NOTE**: Used some bits and pieces from https://github.com/updatecli/policies
 
+## Contributing
+
+See the [contributing documentation](CONTRIBUTING.md).
+
 ## HOWTO
 
 **Login**
@@ -14,7 +18,7 @@ Even though all Updatecli policies published on `ghcr.io` are meant to be public
 
 **Publish**
 
-Each policy defined in this repository is automatically published on ghcr.io via a GitHub Action workflow
+Each policy defined in this repository is automatically published on [ghcr.io](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) via a GitHub Action workflow.
 
 **Show**
 
@@ -43,3 +47,9 @@ policies:
 ```
 
 More information about Updatecli compose feature can be found [here](https://www.updatecli.io/docs/core/compose).
+
+**Enrol a new Repository**
+
+If you want to use the Observability Updatecli policies in a new GitHub repository, you need to
+grant `read` access to the specific policy, this is a private GitHub repository hence a private
+ `ghcr.io`. Those steps are explained in the official [docs](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#ensuring-workflow-access-to-your-package).


### PR DESCRIPTION
Add a bit more of context about how to enrol a new GitHub repository and tests in the CI.