### PR TITLE
fix(ironbank): quote pull request labels

### DIFF
--- a/updatecli/policies/ironbank/templates/CHANGELOG.md
+++ b/updatecli/policies/ironbank/templates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+* Quote the pull request labels so a label starting with a YAML indicator, such as `>non-issue`, no longer breaks the generated manifest.
+
 ## 1.0.0
 
 * Default to UBI 10.

--- a/updatecli/policies/ironbank/templates/Policy.yaml
+++ b/updatecli/policies/ironbank/templates/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/elastic/oblt-updatecli-policies/"
 changelog: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/ironbank/templates/CHANGELOG.md"
 documentation: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/ironbank/templates/README.md"
 source: "https://github.com/elastic/oblt-updatecli-policies/tree/main/updatecli/policies/ironbank/templates/"
-version: 1.0.0
+version: 1.0.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/ironbank/templates/testdata/values.yaml
+++ b/updatecli/policies/ironbank/templates/testdata/values.yaml
@@ -32,3 +32,7 @@ pull_request:
   labels:
     - dependencies
     - backport-active-8
+    # Regression coverage: a label starting with a YAML indicator must not
+    # break the rendered manifest.
+    - ">non-issue"
+    - ":Delivery/Tooling"

--- a/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
+++ b/updatecli/policies/ironbank/templates/updatecli.d/default.tpl
@@ -122,7 +122,7 @@ actions:
       automerge: {{ .automerge }}
       labels:
 # {{ range .pull_request.labels }}
-        - {{ . }}
+        - {{ . | quote }}
 # {{ end }}
     scmid: "default"
 {{ end }}


### PR DESCRIPTION
## What

`ironbank/templates` renders every entry of `pull_request.labels` as a bare YAML scalar:

```gotemplate
      labels:
# {{ range .pull_request.labels }}
        - {{ . }}
# {{ end }}
```

Quoting in the consumer's values file is consumed when that file is parsed, so the template emits the raw string. A label starting with a YAML indicator therefore breaks the generated manifest. `>non-issue` renders as `- >non-issue`, which YAML reads as a folded block scalar header, and loading the manifest fails:

```
✗ Loading manifest ".../ironbank/templates/updatecli.d/default.tpl":
  Error: yaml: line 104: did not find expected comment or line break
```

This is what makes the daily `updatecli-compose` workflow in `elastic/elasticsearch` fail on every branch it runs against (`main`, `8.19`, `9.3`, `9.4`, `9.5`), for example [this run](https://github.com/elastic/elasticsearch/actions/runs/30530697630). Elasticsearch labels its bump PRs with the conventions `>non-issue`, `:Delivery/Tooling` and similar, so the Iron Bank pipeline never loads and the ubi bump never happens.

## How

- Render the labels through `quote`, which emits a YAML double-quoted scalar and also handles labels containing quotes or backslashes.
- Add `>non-issue` and `:Delivery/Tooling` to the policy test data so the case is covered by `make validate-policy` and `make e2e-test`.
- Bump the policy to `1.0.1` and add the changelog entry.

## Verification

With updatecli `v0.113.0` (the version in `.tool-versions`), running the same `updatecli diff` over `updatecli.d` with `values.yaml` + `testdata/values.yaml`, changing only the template line:

```
before:  EXIT=1
  ERROR: failed loading pipeline(s)
    yaml: line 304: did not find expected comment or line break
  ERROR: ✗ no valid pipeline found

after:   EXIT=0
  Run Summary: Changed: 1, Failed: 0   (all 12 targets reported as would-change)
```

The same check against the `elastic/elasticsearch` values files reproduces the reported `line 104` failure before the change and passes after it.

`make test` passes.

## Note for reviewers

`make validate-policy POLICY=policies/ironbank/templates`, the command CONTRIBUTING.md points at, currently fails on `main` as well, so please do not read a red run as a regression from this PR. I confirmed it on a clean worktree of `main`: exit 2 with 12 `no such file or directory` errors.

The cause is unrelated to this change. `.ci/scripts/release.bash` does `pushd updatecli` before invoking updatecli, while the targets in the test data reference `tests/ironbank/templates/...` relative to the repository root. Running the identical `updatecli diff` from the repository root instead gives a fully green run. The label fix is verifiable either way, because the manifest fails to load during `PREPARE`, before any target is evaluated.

Happy to fix the working directory in a separate PR if that is useful.
